### PR TITLE
Refactor BrainState migration logic to a dedicated function

### DIFF
--- a/src/lib/session-export.ts
+++ b/src/lib/session-export.ts
@@ -4,7 +4,7 @@
 import { readFile, rm, writeFile } from "fs/promises"
 import { join } from "path"
 import { existsSync } from "fs"
-import type { BrainState } from "../schemas/brain-state.js"
+import { migrateBrainState, type BrainState } from "../schemas/brain-state.js"
 
 const HIVEMIND_DIR = ".hivemind"
 
@@ -29,7 +29,7 @@ export async function loadSession(
   
   try {
     const content = await readFile(sessionPath, "utf-8")
-    return JSON.parse(content) as BrainState
+    return migrateBrainState(JSON.parse(content))
   } catch {
     return null
   }


### PR DESCRIPTION
Extracted the state migration logic into a dedicated `migrateBrainState` function in `src/schemas/brain-state.ts` to improve code health and maintainability. Updated `src/lib/persistence.ts` and `src/lib/session-export.ts` to use this function. Added comprehensive tests for the migration logic.

---
*PR created automatically by Jules for task [17930129787565584171](https://jules.google.com/task/17930129787565584171) started by @shynlee04*