### PR TITLE
Refactor hierarchy rendering to use unified renderNode helper

### DIFF
--- a/src/lib/hierarchy-tree.ts
+++ b/src/lib/hierarchy-tree.ts
@@ -571,6 +571,80 @@ const STATUS_MARKERS: Record<ContextStatus, string> = {
   blocked: "!!",
 };
 
+export interface RenderOptions {
+  /** Output format: ascii tree, markdown list, or summary string */
+  format: "ascii" | "markdown" | "summary";
+  /** Whether this node is the current cursor */
+  isCursor?: boolean;
+}
+
+/**
+ * Unified node rendering helper.
+ * Generates a string representation of a node for various outputs.
+ *
+ * @consumer toAsciiTree, toActiveMdBody, summarizeBranch
+ */
+export function renderNode(node: HierarchyNode, { format, isCursor }: RenderOptions): string {
+  // 1. Status Marker
+  let statusStr = "";
+  if (format === "markdown") {
+    statusStr = node.status === "complete" ? "[x]" : "[ ]";
+  } else if (format === "summary") {
+    statusStr = `[${node.status === "complete" ? "DONE" : node.status.toUpperCase()}]`;
+  } else {
+    // ascii
+    statusStr = `[${STATUS_MARKERS[node.status]}]`;
+  }
+
+  // 2. Level Label (optional)
+  let levelStr = "";
+  if (format === "ascii") {
+    const label = node.level.charAt(0).toUpperCase() + node.level.slice(1);
+    levelStr = `${label}: `;
+  } else if (format === "markdown") {
+    levelStr = `**${node.level}**: `;
+  }
+  // summary omits level
+
+  // 3. Content
+  let contentStr = node.content;
+  if (format === "ascii" && contentStr.length > 60) {
+    contentStr = contentStr.slice(0, 57) + "...";
+  }
+
+  // 4. Metadata (Stamp + Child Count)
+  let metaStr = "";
+  if (format === "summary") {
+    const childCount = flattenTree(node).length - 1; // exclude self
+    metaStr = ` (${childCount} sub-items, ${node.stamp})`;
+  } else if (format === "markdown") {
+    metaStr = ` _(${node.stamp})_`;
+  } else {
+    // ascii
+    metaStr = ` (${node.stamp})`;
+  }
+
+  // 5. Cursor Marker
+  let cursorStr = "";
+  if (isCursor) {
+    if (format === "markdown") {
+      cursorStr = " **<< CURRENT**";
+    } else if (format === "ascii") {
+      cursorStr = " <-- cursor";
+    }
+  }
+
+  // Assemble
+  if (format === "markdown") {
+    return `- ${statusStr} ${levelStr}${contentStr}${metaStr}${cursorStr}`;
+  } else if (format === "summary") {
+    return `${statusStr} ${contentStr}${metaStr}`;
+  } else {
+    // ascii
+    return `${statusStr} ${levelStr}${contentStr}${metaStr}${cursorStr}`;
+  }
+}
+
 /**
  * Render the tree as an ASCII tree string.
  * Marks the cursor node with an arrow.
@@ -582,24 +656,22 @@ export function toAsciiTree(tree: HierarchyTree): string {
 
   const lines: string[] = [];
 
-  function renderNode(node: HierarchyNode, prefix: string, isLast: boolean, isRoot: boolean): void {
+  function visit(node: HierarchyNode, prefix: string, isLast: boolean, isRoot: boolean): void {
     const connector = isRoot ? "" : isLast ? "\\-- " : "|-- ";
-    const marker = STATUS_MARKERS[node.status];
-    const cursorMark = tree.cursor === node.id ? " <-- cursor" : "";
-    const truncatedContent = node.content.length > 60
-      ? node.content.slice(0, 57) + "..."
-      : node.content;
+    const nodeString = renderNode(node, {
+      format: "ascii",
+      isCursor: tree.cursor === node.id
+    });
 
-    const levelLabel = node.level.charAt(0).toUpperCase() + node.level.slice(1);
-    lines.push(`${prefix}${connector}[${marker}] ${levelLabel}: ${truncatedContent} (${node.stamp})${cursorMark}`);
+    lines.push(`${prefix}${connector}${nodeString}`);
 
     const childPrefix = isRoot ? "" : prefix + (isLast ? "    " : "|   ");
     for (let i = 0; i < node.children.length; i++) {
-      renderNode(node.children[i], childPrefix, i === node.children.length - 1, false);
+      visit(node.children[i], childPrefix, i === node.children.length - 1, false);
     }
   }
 
-  renderNode(tree.root, "", true, true);
+  visit(tree.root, "", true, true);
   return lines.join("\n");
 }
 
@@ -613,18 +685,21 @@ export function toActiveMdBody(tree: HierarchyTree): string {
 
   const lines: string[] = [];
 
-  function renderNode(node: HierarchyNode, depth: number): void {
+  function visit(node: HierarchyNode, depth: number): void {
     const indent = "  ".repeat(depth);
-    const statusMark = node.status === "complete" ? "[x]" : "[ ]";
-    const cursorMark = tree.cursor === node.id ? " **<< CURRENT**" : "";
-    lines.push(`${indent}- ${statusMark} **${node.level}**: ${node.content} _(${node.stamp})_${cursorMark}`);
+    const nodeString = renderNode(node, {
+      format: "markdown",
+      isCursor: tree.cursor === node.id
+    });
+
+    lines.push(`${indent}${nodeString}`);
 
     for (const child of node.children) {
-      renderNode(child, depth + 1);
+      visit(child, depth + 1);
     }
   }
 
-  renderNode(tree.root, 0);
+  visit(tree.root, 0);
   return lines.join("\n");
 }
 
@@ -681,9 +756,7 @@ export function countCompleted(tree: HierarchyTree): number {
  * @consumer pruneCompleted
  */
 export function summarizeBranch(node: HierarchyNode): string {
-  const childCount = flattenTree(node).length - 1; // exclude self
-  const status = node.status === "complete" ? "DONE" : node.status.toUpperCase();
-  return `[${status}] ${node.content} (${childCount} sub-items, ${node.stamp})`;
+  return renderNode(node, { format: "summary" });
 }
 
 /**


### PR DESCRIPTION
This PR refactors the hierarchy rendering logic in `src/lib/hierarchy-tree.ts` to reduce code duplication and improve maintainability.

**Changes:**
- Implemented `renderNode` helper function that centralizes node string formatting.
- Updated `summarizeBranch`, `toAsciiTree`, and `toActiveMdBody` to use this new helper.
- Ensured all existing formatting requirements (truncation, status markers, markdown syntax) are preserved.

**Verification:**
- Ran `npm test` to ensure no regressions in hierarchy rendering or summary generation.
- Checked `lint:boundary` to ensure architectural compliance.

---
*PR created automatically by Jules for task [18423230187475283124](https://jules.google.com/task/18423230187475283124) started by @shynlee04*