### PR TITLE
🔒 Fix path traversal in session file resolution

### DIFF
--- a/src/lib/planning-fs.ts
+++ b/src/lib/planning-fs.ts
@@ -17,7 +17,7 @@
 
 import { readFile, writeFile, mkdir, readdir, rename } from "fs/promises";
 import { existsSync } from "fs";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 import { parse, stringify } from "yaml";
 import {
   buildArchiveFilename,
@@ -321,10 +321,11 @@ async function resolveSessionFilePathByStamp(
     if (existsSync(sessionPath)) return sessionPath
   }
 
-  const byStampInActiveDir = join(getEffectivePaths(projectRoot).activeDir, `${stamp}.md`)
+  const sanitizedStamp = basename(stamp)
+  const byStampInActiveDir = join(getEffectivePaths(projectRoot).activeDir, `${sanitizedStamp}.md`)
   if (existsSync(byStampInActiveDir)) return byStampInActiveDir
 
-  const byStampInSessionsDir = join(paths.sessionsDir, `${stamp}.md`)
+  const byStampInSessionsDir = join(paths.sessionsDir, `${sanitizedStamp}.md`)
   if (existsSync(byStampInSessionsDir)) return byStampInSessionsDir
 
   return byStampInActiveDir


### PR DESCRIPTION
Sanitized the `stamp` parameter in `resolveSessionFilePathByStamp` using `path.basename`.
This prevents attackers from accessing arbitrary files by supplying a malicious `stamp` containing path traversal sequences (e.g., `../../../etc/passwd`).
Verified the fix with a reproduction script and ran existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [16806310767228650285](https://jules.google.com/task/16806310767228650285) started by @shynlee04*