### PR TITLE
Fix Issue 22 Archive Chaos (Overwrite Prevention)

### DIFF
--- a/src/lib/planning-fs.ts
+++ b/src/lib/planning-fs.ts
@@ -17,7 +17,7 @@
 
 import { readFile, writeFile, mkdir, readdir, rename } from "fs/promises";
 import { existsSync } from "fs";
-import { dirname, join } from "path";
+import { dirname, join, extname, basename } from "path";
 import { parse, stringify } from "yaml";
 import {
   buildArchiveFilename,
@@ -740,9 +740,18 @@ export async function archiveSession(
     ]
     const srcPath = sourceCandidates.find((p) => p && existsSync(p))
 
-    const archiveFileName = safeEntryFile && /^\d{4}-\d{2}-\d{2}-/.test(safeEntryFile)
+    const baseArchiveFileName = safeEntryFile && /^\d{4}-\d{2}-\d{2}-/.test(safeEntryFile)
       ? safeEntryFile
       : buildArchiveFilename(new Date(entry.created || Date.now()), entry.mode || "plan_driven", entry.trajectory || "session")
+
+    let archiveFileName = baseArchiveFileName
+    let counter = 1
+    while (existsSync(join(paths.archiveDir, archiveFileName))) {
+      const ext = extname(baseArchiveFileName)
+      const name = basename(baseArchiveFileName, ext)
+      archiveFileName = `${name}-${counter}${ext}`
+      counter++
+    }
     const dstPath = join(paths.archiveDir, archiveFileName)
 
     let archiveContent = content


### PR DESCRIPTION
This change modifies `archiveSession` in `src/lib/planning-fs.ts` to ensure that archived session filenames are unique. If a file with the same name exists, it appends a counter to prevent overwriting existing data. This addresses the data loss chaos described in Issue 22, where multiple sessions with the same date and trajectory would overwrite each other upon archival. Verified with reproduction tests.

---
*PR created automatically by Jules for task [7404516098921846496](https://jules.google.com/task/7404516098921846496) started by @shynlee04*