### PR TITLE
Refactor compileSignals to be declarative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "hivemind-context-governance",
       "version": "2.6.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
+        "typescript": "^5.3.0",
         "yaml": "^2.3.4"
       },
       "bin": {


### PR DESCRIPTION
Refactored `compileSignals` in `src/lib/detection.ts` to use a declarative list of signal detectors, improving extensibility and readability.

- Extracted `SignalDetectionOptions` interface.
- Defined `SignalDetector` type and implemented individual detector functions.
- Replaced imperative `if` checks with a loop over `SIGNAL_DETECTORS`.
- Verified with existing tests.

---
*PR created automatically by Jules for task [420383508061840709](https://jules.google.com/task/420383508061840709) started by @shynlee04*