### PR TITLE
Phase B Track C: auto-commit module + governance wiring

### DIFF
--- a/src/lib/auto-commit.ts
+++ b/src/lib/auto-commit.ts
@@ -1,0 +1,102 @@
+import { getShell } from "../hooks/sdk-context.js"
+
+type BunShell = (strings: TemplateStringsArray, ...values: unknown[]) => Promise<unknown>
+
+export interface AutoCommitContext {
+  tool: string
+  directory: string
+  sessionID?: string
+  files?: string[]
+  shell?: BunShell | null
+}
+
+export interface AutoCommitResult {
+  success: boolean
+  message: string
+}
+
+const AUTO_COMMIT_TOOLS = new Set(["write", "edit", "bash"])
+
+export function shouldAutoCommit(tool: string): boolean {
+  return AUTO_COMMIT_TOOLS.has(tool)
+}
+
+function normalizeToolName(tool: string): string {
+  const normalized = tool.trim().toLowerCase().replace(/[^a-z0-9_-]/g, "-")
+  return normalized || "tool"
+}
+
+export function generateCommitMessage(ctx: AutoCommitContext): string {
+  const toolName = normalizeToolName(ctx.tool)
+  const fileCount = ctx.files?.length ?? 0
+  const fileSegment = fileCount > 0
+    ? `${fileCount} file change${fileCount === 1 ? "" : "s"}`
+    : "changes"
+
+  return `chore(auto-commit): persist ${fileSegment} after ${toolName}`
+}
+
+function collectMetadataPaths(value: unknown, paths: string[]): void {
+  if (!value) return
+
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (trimmed) paths.push(trimmed)
+    return
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectMetadataPaths(entry, paths)
+    }
+    return
+  }
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>
+    const directPath = record.path ?? record.file ?? record.filePath ?? record.name
+    if (typeof directPath === "string") {
+      collectMetadataPaths(directPath, paths)
+    }
+
+    for (const entry of Object.values(record)) {
+      collectMetadataPaths(entry, paths)
+    }
+  }
+}
+
+export function extractModifiedFiles(metadata: unknown, fallbackPaths: string[] = []): string[] {
+  const paths: string[] = []
+  collectMetadataPaths(metadata, paths)
+
+  for (const fallback of fallbackPaths) {
+    if (typeof fallback === "string") {
+      paths.push(fallback)
+    }
+  }
+
+  const normalized = paths
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && !entry.startsWith("[via "))
+
+  return [...new Set(normalized)]
+}
+
+export async function executeAutoCommit(ctx: AutoCommitContext): Promise<AutoCommitResult> {
+  const shell = ctx.shell ?? getShell()
+  if (!shell) {
+    return { success: false, message: "Auto-commit skipped: shell unavailable" }
+  }
+
+  const files = ctx.files ?? []
+  const commitMessage = generateCommitMessage({ ...ctx, files })
+
+  try {
+    await shell`git -C ${ctx.directory} add -A`
+    await shell`git -C ${ctx.directory} commit -m ${commitMessage}`
+    return { success: true, message: commitMessage }
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error)
+    return { success: false, message: `Auto-commit failed: ${detail}` }
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,6 +10,7 @@ export * from "./complexity.js";
 export * from "./staleness.js";
 export * from "./chain-analysis.js";
 export * from "./commit-advisor.js";
+export * from "./auto-commit.js";
 export * from "./tool-activation.js";
 export * from "./session-export.js";
 export * from "./long-session.js"

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -58,6 +58,8 @@ export interface HiveMindConfig {
   stale_session_days: number;
   /** Files touched threshold before suggesting a commit */
   commit_suggestion_threshold: number;
+  /** Enable auto-commit after write/edit/bash tools when changes are detected */
+  auto_commit: boolean;
   /** Agent behavior configuration - injected into every session */
   agent_behavior: AgentBehaviorConfig;
   /** Override detection thresholds (merged with defaults at runtime) */
@@ -87,6 +89,7 @@ export const DEFAULT_CONFIG: HiveMindConfig = {
   auto_compact_on_turns: 20,
   stale_session_days: 3,
   commit_suggestion_threshold: 5,
+  auto_commit: false,
   agent_behavior: DEFAULT_AGENT_BEHAVIOR,
   automation_level: "assisted" as AutomationLevel,
 };

--- a/tests/auto-commit.test.ts
+++ b/tests/auto-commit.test.ts
@@ -1,0 +1,141 @@
+import {
+  executeAutoCommit,
+  extractModifiedFiles,
+  generateCommitMessage,
+  shouldAutoCommit,
+} from "../src/lib/auto-commit.js"
+
+let passed = 0
+let failed_ = 0
+
+function assert(cond: boolean, name: string) {
+  if (cond) {
+    passed++
+    process.stderr.write(`  PASS: ${name}\n`)
+  } else {
+    failed_++
+    process.stderr.write(`  FAIL: ${name}\n`)
+  }
+}
+
+function createMockShell(opts: { failCommit?: boolean } = {}) {
+  const commands: string[] = []
+
+  const shell = async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    let command = strings[0] ?? ""
+    for (let index = 0; index < values.length; index++) {
+      command += String(values[index])
+      command += strings[index + 1] ?? ""
+    }
+    const normalized = command.trim()
+    commands.push(normalized)
+
+    if (opts.failCommit && normalized.includes("git -C") && normalized.includes("commit -m")) {
+      throw new Error("nothing to commit, working tree clean")
+    }
+
+    return { stdout: "", stderr: "" }
+  }
+
+  return {
+    shell: shell as any,
+    commands,
+  }
+}
+
+function test_shouldAutoCommit() {
+  process.stderr.write("\n--- auto-commit: shouldAutoCommit ---\n")
+  assert(shouldAutoCommit("write"), "write tool is auto-committable")
+  assert(shouldAutoCommit("edit"), "edit tool is auto-committable")
+  assert(shouldAutoCommit("bash"), "bash tool is auto-committable")
+  assert(!shouldAutoCommit("read"), "read tool is not auto-committable")
+}
+
+function test_generateCommitMessage() {
+  process.stderr.write("\n--- auto-commit: generateCommitMessage ---\n")
+  const withFiles = generateCommitMessage({
+    tool: "write",
+    directory: "/tmp/project",
+    files: ["src/a.ts", "src/b.ts"],
+  })
+  assert(withFiles.startsWith("chore(auto-commit):"), "commit message uses conventional prefix")
+  assert(withFiles.includes("2 file changes"), "commit message includes file count")
+
+  const withoutFiles = generateCommitMessage({
+    tool: "edit",
+    directory: "/tmp/project",
+  })
+  assert(withoutFiles.includes("after edit"), "commit message includes normalized tool name")
+}
+
+function test_extractModifiedFiles() {
+  process.stderr.write("\n--- auto-commit: extractModifiedFiles ---\n")
+  const metadata = {
+    modifiedFiles: ["src/a.ts", { path: "src/b.ts" }],
+    details: {
+      changed_files: ["src/c.ts", { filePath: "src/d.ts" }],
+    },
+  }
+
+  const files = extractModifiedFiles(metadata, ["[via write]", "src/e.ts"])
+  assert(files.length === 5, "extracts and de-duplicates modified files")
+  assert(files.includes("src/a.ts"), "extract includes direct file entry")
+  assert(files.includes("src/d.ts"), "extract includes nested object entry")
+  assert(!files.some((entry) => entry.startsWith("[via ")), "extract filters synthetic fallback markers")
+}
+
+async function test_executeAutoCommitSuccess() {
+  process.stderr.write("\n--- auto-commit: execute success ---\n")
+  const { shell, commands } = createMockShell()
+  const result = await executeAutoCommit({
+    tool: "write",
+    directory: "/tmp/project",
+    files: ["src/a.ts"],
+    shell,
+  })
+
+  assert(result.success, "executeAutoCommit returns success when git commands succeed")
+  assert(commands.length === 2, "executeAutoCommit runs add and commit")
+  assert(commands[0] === "git -C /tmp/project add -A", "executeAutoCommit runs git add")
+  assert(commands[1].includes("git -C /tmp/project commit -m"), "executeAutoCommit runs git commit")
+}
+
+async function test_executeAutoCommitFailure() {
+  process.stderr.write("\n--- auto-commit: execute failure ---\n")
+  const { shell } = createMockShell({ failCommit: true })
+  const result = await executeAutoCommit({
+    tool: "write",
+    directory: "/tmp/project",
+    shell,
+  })
+
+  assert(!result.success, "executeAutoCommit returns failure when commit fails")
+  assert(result.message.includes("Auto-commit failed"), "failure includes auto-commit error message")
+}
+
+async function test_executeAutoCommitNoShell() {
+  process.stderr.write("\n--- auto-commit: no shell fallback ---\n")
+  const result = await executeAutoCommit({
+    tool: "write",
+    directory: "/tmp/project",
+    shell: null,
+  })
+  assert(!result.success, "executeAutoCommit returns failure when shell is unavailable")
+  assert(result.message.includes("shell unavailable"), "no shell failure message is clear")
+}
+
+async function main() {
+  process.stderr.write("=== Auto-commit Tests ===\n")
+
+  test_shouldAutoCommit()
+  test_generateCommitMessage()
+  test_extractModifiedFiles()
+  await test_executeAutoCommitSuccess()
+  await test_executeAutoCommitFailure()
+  await test_executeAutoCommitNoShell()
+
+  process.stderr.write(`\n=== Auto-commit: ${passed} passed, ${failed_} failed ===\n`)
+  if (failed_ > 0) process.exit(1)
+}
+
+main()


### PR DESCRIPTION
## Summary
- Add reusable `src/lib/auto-commit.ts` with detection, metadata extraction, and safe execution helpers.
- Wire optional auto-commit behavior into `soft-governance` after file-changing tool runs.
- Extend config schema/tests to support `auto_commit` flag and non-blocking failure behavior.

## Validation
- `npm test`
- `npm run typecheck`

## Scope
- US-006, US-007 from `tasks/prd-phase-b.json`