### PR TITLE
Phase B Track A: messages transform + continuity

### DIFF
--- a/src/hooks/messages-transform.ts
+++ b/src/hooks/messages-transform.ts
@@ -59,7 +59,16 @@ export function createMessagesTransformHook(_log: { warn: (message: string) => P
 
       const items: string[] = []
       if (!state.hierarchy.action) {
-        items.push("Declare action-level focus before stopping")
+        items.push("Action-level focus is missing (call map_context)")
+      }
+      if (state.metrics.context_updates === 0) {
+        items.push("No map_context updates yet in this session")
+      }
+      if (state.pending_failure_ack) {
+        items.push("Acknowledge pending subagent failure")
+      }
+      if (state.metrics.files_touched.length > 0) {
+        items.push("Create a git commit for touched files")
       }
 
       const checklist = buildChecklist(items, 300)

--- a/src/hooks/messages-transform.ts
+++ b/src/hooks/messages-transform.ts
@@ -1,0 +1,73 @@
+import { createStateManager, loadConfig } from "../lib/persistence.js"
+
+type MessagePart = {
+  type?: string
+  text?: string
+  synthetic?: boolean
+  [key: string]: unknown
+}
+
+export interface MessageV2 {
+  role?: string
+  content?: string | MessagePart[]
+  synthetic?: boolean
+  [key: string]: unknown
+}
+
+function buildChecklist(items: string[], maxChars: number): string {
+  if (items.length === 0) return ""
+
+  const lines = ["<system-reminder>", "CHECKLIST BEFORE STOPPING:"]
+  for (const item of items) {
+    const candidate = [...lines, `- [ ] ${item}`, "</system-reminder>"].join("\n")
+    if (candidate.length > maxChars) break
+    lines.push(`- [ ] ${item}`)
+  }
+  lines.push("</system-reminder>")
+  return lines.join("\n")
+}
+
+function syntheticSystemMessage(text: string): MessageV2 {
+  return {
+    role: "system",
+    synthetic: true,
+    content: [
+      {
+        type: "text",
+        text,
+        synthetic: true,
+      },
+    ],
+  }
+}
+
+export function createMessagesTransformHook(_log: { warn: (message: string) => Promise<void> }, directory: string) {
+  const stateManager = createStateManager(directory)
+
+  return async (
+    _input: {},
+    output: { messages: MessageV2[] }
+  ): Promise<void> => {
+    try {
+      if (!Array.isArray(output.messages)) return
+
+      const config = await loadConfig(directory)
+      if (config.governance_mode === "permissive") return
+
+      const state = await stateManager.load()
+      if (!state) return
+
+      const items: string[] = []
+      if (!state.hierarchy.action) {
+        items.push("Declare action-level focus before stopping")
+      }
+
+      const checklist = buildChecklist(items, 300)
+      if (!checklist) return
+
+      output.messages.push(syntheticSystemMessage(checklist))
+    } catch {
+      // P3: never break message flow
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
   createCompactionHook,
   createEventHandler,
 } from "./hooks/index.js"
+import { createMessagesTransformHook } from "./hooks/messages-transform.js"
 import { createLogger } from "./lib/logging.js"
 import { loadConfig } from "./lib/persistence.js"
 import { initSdkContext } from "./hooks/sdk-context.js"
@@ -126,6 +127,12 @@ export const HiveMindPlugin: Plugin = async ({
      */
     "experimental.chat.system.transform":
       createSessionLifecycleHook(log, effectiveDir, initConfig),
+
+    /**
+     * Hook: Message transformation
+     * Injects stop-decision checklist and continuity context
+     */
+    "experimental.chat.messages.transform": createMessagesTransformHook(log, effectiveDir),
 
     /**
      * Hook: Tool execution tracking

--- a/src/lib/session-boundary.ts
+++ b/src/lib/session-boundary.ts
@@ -1,0 +1,81 @@
+/**
+ * Session Boundary Manager — pure recommendation helpers.
+ * Decides when a fresh session is recommended at natural boundaries.
+ */
+
+export interface SessionBoundaryState {
+  turnCount: number
+  contextPercent: number
+  hierarchyComplete: boolean
+  isMainSession: boolean
+  hasDelegations: boolean
+}
+
+export interface SessionBoundaryRecommendation {
+  recommended: boolean
+  reason: string
+}
+
+/**
+ * Estimates context usage percentage from turn count and compact threshold.
+ */
+export function estimateContextPercent(
+  turnCount: number,
+  compactThreshold: number
+): number {
+  const safeThreshold = Math.max(1, compactThreshold)
+  const percent = Math.round((Math.max(0, turnCount) / safeThreshold) * 100)
+  return Math.min(100, percent)
+}
+
+/**
+ * Returns whether a fresh session should be recommended.
+ * Rules:
+ * - Main session only (exclude delegated/subagent contexts)
+ * - Session should still have headroom (context < 80%)
+ * - Natural boundary reached (completed phase/epic)
+ * - Turn count should be substantial (30+)
+ */
+export function shouldCreateNewSession(
+  state: SessionBoundaryState
+): SessionBoundaryRecommendation {
+  if (!state.isMainSession) {
+    return {
+      recommended: false,
+      reason: "Boundary recommendation only applies to the main session",
+    }
+  }
+
+  if (state.hasDelegations) {
+    return {
+      recommended: false,
+      reason: "Active delegations detected; finish delegation flow before creating a new session",
+    }
+  }
+
+  if (state.contextPercent >= 80) {
+    return {
+      recommended: false,
+      reason: `Context usage is ${state.contextPercent}% (must be below 80% for a clean handoff boundary)`,
+    }
+  }
+
+  if (state.turnCount < 30) {
+    return {
+      recommended: false,
+      reason: `Turn threshold not met (${state.turnCount}/30)`,
+    }
+  }
+
+  if (!state.hierarchyComplete) {
+    return {
+      recommended: false,
+      reason: "No completed phase/epic boundary detected yet",
+    }
+  }
+
+  return {
+    recommended: true,
+    reason: `Natural boundary reached (${state.turnCount} turns, ${state.contextPercent}% context, completed phase/epic detected)`,
+  }
+}

--- a/tests/messages-transform.test.ts
+++ b/tests/messages-transform.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, rm } from "fs/promises"
+import { tmpdir } from "os"
+import { join } from "path"
+import { createMessagesTransformHook, type MessageV2 } from "../src/hooks/messages-transform.js"
+import { initializePlanningDirectory } from "../src/lib/planning-fs.js"
+import { createStateManager, saveConfig } from "../src/lib/persistence.js"
+import { createBrainState, generateSessionId, unlockSession } from "../src/schemas/brain-state.js"
+import { createConfig } from "../src/schemas/config.js"
+
+let passed = 0
+let failed_ = 0
+
+function assert(cond: boolean, name: string) {
+  if (cond) {
+    passed++
+    process.stderr.write(`  PASS: ${name}\n`)
+  } else {
+    failed_++
+    process.stderr.write(`  FAIL: ${name}\n`)
+  }
+}
+
+async function setupDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "hm-msg-transform-"))
+  await initializePlanningDirectory(dir)
+  return dir
+}
+
+async function test_injects_checklist_message() {
+  process.stderr.write("\n--- messages-transform: inject checklist ---\n")
+  const dir = await setupDir()
+  const config = createConfig({ governance_mode: "assisted" })
+  await saveConfig(dir, config)
+
+  const stateManager = createStateManager(dir)
+  const state = unlockSession(createBrainState(generateSessionId(), config))
+  await stateManager.save(state)
+
+  const hook = createMessagesTransformHook({ warn: async () => {} }, dir)
+  const output: { messages: MessageV2[] } = {
+    messages: [{ role: "user", content: "hi" }],
+  }
+
+  await hook({}, output)
+
+  const injected = output.messages[output.messages.length - 1]
+  const part = Array.isArray(injected?.content) ? injected.content[0] : null
+  const text = typeof part?.text === "string" ? part.text : ""
+
+  assert(output.messages.length === 2, "adds one synthetic reminder message")
+  assert(injected?.role === "system", "injected message role is system")
+  assert(part?.synthetic === true, "injected part marked synthetic")
+  assert(text.includes("CHECKLIST BEFORE STOPPING"), "injected text includes checklist header")
+
+  await rm(dir, { recursive: true, force: true })
+}
+
+async function test_skips_permissive_mode() {
+  process.stderr.write("\n--- messages-transform: skip permissive mode ---\n")
+  const dir = await setupDir()
+  const config = createConfig({ governance_mode: "permissive" })
+  await saveConfig(dir, config)
+
+  const stateManager = createStateManager(dir)
+  const state = unlockSession(createBrainState(generateSessionId(), config))
+  await stateManager.save(state)
+
+  const hook = createMessagesTransformHook({ warn: async () => {} }, dir)
+  const output: { messages: MessageV2[] } = {
+    messages: [{ role: "user", content: "hi" }],
+  }
+
+  await hook({}, output)
+
+  assert(output.messages.length === 1, "does not inject reminder in permissive mode")
+  await rm(dir, { recursive: true, force: true })
+}
+
+async function main() {
+  process.stderr.write("=== Messages Transform Tests ===\n")
+
+  await test_injects_checklist_message()
+  await test_skips_permissive_mode()
+
+  process.stderr.write(`\n=== Messages Transform: ${passed} passed, ${failed_} failed ===\n`)
+  if (failed_ > 0) process.exit(1)
+}
+
+main()

--- a/tests/session-boundary.test.ts
+++ b/tests/session-boundary.test.ts
@@ -1,0 +1,69 @@
+import {
+  estimateContextPercent,
+  shouldCreateNewSession,
+} from "../src/lib/session-boundary.js"
+
+let passed = 0
+let failed_ = 0
+
+function assert(cond: boolean, name: string) {
+  if (cond) {
+    passed++
+    process.stderr.write(`  PASS: ${name}\n`)
+  } else {
+    failed_++
+    process.stderr.write(`  FAIL: ${name}\n`)
+  }
+}
+
+function testEstimateContextPercent() {
+  process.stderr.write("\n--- session-boundary: estimateContextPercent ---\n")
+
+  assert(estimateContextPercent(0, 20) === 0, "0 turns on threshold 20 => 0%")
+  assert(estimateContextPercent(10, 20) === 50, "10 turns on threshold 20 => 50%")
+  assert(estimateContextPercent(25, 20) === 100, "percent is capped at 100")
+  assert(estimateContextPercent(5, 0) === 100, "zero threshold is clamped safely")
+}
+
+function testShouldCreateNewSessionRules() {
+  process.stderr.write("\n--- session-boundary: shouldCreateNewSession ---\n")
+
+  const base = {
+    turnCount: 35,
+    contextPercent: 60,
+    hierarchyComplete: true,
+    isMainSession: true,
+    hasDelegations: false,
+  }
+
+  const nonMain = shouldCreateNewSession({ ...base, isMainSession: false })
+  assert(nonMain.recommended === false, "non-main session is excluded")
+
+  const withDelegations = shouldCreateNewSession({ ...base, hasDelegations: true })
+  assert(withDelegations.recommended === false, "delegation-active session is excluded")
+
+  const highContext = shouldCreateNewSession({ ...base, contextPercent: 80 })
+  assert(highContext.recommended === false, "context must be below 80%")
+
+  const lowTurns = shouldCreateNewSession({ ...base, turnCount: 29 })
+  assert(lowTurns.recommended === false, "turn threshold requires 30+")
+
+  const noBoundary = shouldCreateNewSession({ ...base, hierarchyComplete: false })
+  assert(noBoundary.recommended === false, "requires completed phase/epic boundary")
+
+  const recommended = shouldCreateNewSession(base)
+  assert(recommended.recommended === true, "recommends new session when all rules match")
+  assert(recommended.reason.includes("Natural boundary reached"), "recommendation reason is explicit")
+}
+
+function main() {
+  process.stderr.write("=== Session Boundary Tests ===\n")
+
+  testEstimateContextPercent()
+  testShouldCreateNewSessionRules()
+
+  process.stderr.write(`\n=== Session Boundary: ${passed} passed, ${failed_} failed ===\n`)
+  if (failed_ > 0) process.exit(1)
+}
+
+main()

--- a/tests/session-lifecycle-boundary.test.ts
+++ b/tests/session-lifecycle-boundary.test.ts
@@ -1,0 +1,82 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { initProject } from "../src/cli/init.js"
+import { createSessionLifecycleHook } from "../src/hooks/session-lifecycle.js"
+import { createTree, createNode, setRoot, saveTree } from "../src/lib/hierarchy-tree.js"
+import { createStateManager, loadConfig, saveConfig } from "../src/lib/persistence.js"
+
+let passed = 0
+let failed_ = 0
+
+function assert(cond: boolean, name: string) {
+  if (cond) {
+    passed++
+    process.stderr.write(`  PASS: ${name}\n`)
+  } else {
+    failed_++
+    process.stderr.write(`  FAIL: ${name}\n`)
+  }
+}
+
+async function testBoundaryWarningInjectedWhenConditionsAreMet() {
+  process.stderr.write("\n--- session-lifecycle: boundary warning injection ---\n")
+
+  const dir = await mkdtemp(join(tmpdir(), "hm-boundary-"))
+
+  try {
+    await initProject(dir, { governanceMode: "assisted", language: "en", silent: true })
+
+    const config = await loadConfig(dir)
+    await saveConfig(dir, {
+      ...config,
+      auto_compact_on_turns: 50,
+    })
+
+    const stateManager = createStateManager(dir)
+    const state = await stateManager.load()
+    if (!state) {
+      throw new Error("missing state after init")
+    }
+
+    state.metrics.turn_count = 35
+    state.session.role = "main"
+    state.cycle_log = []
+    await stateManager.save(state)
+
+    const root = createNode("trajectory", "Phase B complete", "complete")
+    const tree = setRoot(createTree(), root)
+    await saveTree(dir, tree)
+
+    const logger = {
+      debug: async (_message: string) => {},
+      info: async (_message: string) => {},
+      warn: async (_message: string) => {},
+      error: async (_message: string) => {},
+    }
+
+    const lifecycleConfig = await loadConfig(dir)
+    const hook = createSessionLifecycleHook(logger, dir, lifecycleConfig)
+    const output = { system: [] as string[] }
+
+    await hook({ sessionID: "test-session" }, output)
+
+    const text = output.system.join("\n")
+    assert(text.includes("🔄 Natural boundary reached"), "includes boundary recommendation line")
+    assert(text.includes("→ Run /hivemind-compact to archive and start fresh"), "includes compact handoff instruction")
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+async function main() {
+  process.stderr.write("=== Session Lifecycle Boundary Integration Tests ===\n")
+
+  await testBoundaryWarningInjectedWhenConditionsAreMet()
+
+  process.stderr.write(`\n=== Session Lifecycle Boundary: ${passed} passed, ${failed_} failed ===\n`)
+  if (failed_ > 0) process.exit(1)
+}
+
+await main()


### PR DESCRIPTION
## Summary
- Add `experimental.chat.messages.transform` hook with stop-checklist injection and dynamic governance signals.
- Add user-message continuity augmentation using hierarchy focus and immutable anchors.
- Register the new hook in plugin entry so it executes on chat turns.

## Validation
- `npm test`
- `npm run typecheck`

## Scope
- US-001, US-002, US-003, US-003-A from `tasks/prd-phase-b.json`