### PR TITLE
Phase B Track D: session boundaries + non-disruptive session rollover

### DIFF
--- a/src/lib/session-boundary.ts
+++ b/src/lib/session-boundary.ts
@@ -1,0 +1,81 @@
+/**
+ * Session Boundary Manager — pure recommendation helpers.
+ * Decides when a fresh session is recommended at natural boundaries.
+ */
+
+export interface SessionBoundaryState {
+  turnCount: number
+  contextPercent: number
+  hierarchyComplete: boolean
+  isMainSession: boolean
+  hasDelegations: boolean
+}
+
+export interface SessionBoundaryRecommendation {
+  recommended: boolean
+  reason: string
+}
+
+/**
+ * Estimates context usage percentage from turn count and compact threshold.
+ */
+export function estimateContextPercent(
+  turnCount: number,
+  compactThreshold: number
+): number {
+  const safeThreshold = Math.max(1, compactThreshold)
+  const percent = Math.round((Math.max(0, turnCount) / safeThreshold) * 100)
+  return Math.min(100, percent)
+}
+
+/**
+ * Returns whether a fresh session should be recommended.
+ * Rules:
+ * - Main session only (exclude delegated/subagent contexts)
+ * - Session should still have headroom (context < 80%)
+ * - Natural boundary reached (completed phase/epic)
+ * - Turn count should be substantial (30+)
+ */
+export function shouldCreateNewSession(
+  state: SessionBoundaryState
+): SessionBoundaryRecommendation {
+  if (!state.isMainSession) {
+    return {
+      recommended: false,
+      reason: "Boundary recommendation only applies to the main session",
+    }
+  }
+
+  if (state.hasDelegations) {
+    return {
+      recommended: false,
+      reason: "Active delegations detected; finish delegation flow before creating a new session",
+    }
+  }
+
+  if (state.contextPercent >= 80) {
+    return {
+      recommended: false,
+      reason: `Context usage is ${state.contextPercent}% (must be below 80% for a clean handoff boundary)`,
+    }
+  }
+
+  if (state.turnCount < 30) {
+    return {
+      recommended: false,
+      reason: `Turn threshold not met (${state.turnCount}/30)`,
+    }
+  }
+
+  if (!state.hierarchyComplete) {
+    return {
+      recommended: false,
+      reason: "No completed phase/epic boundary detected yet",
+    }
+  }
+
+  return {
+    recommended: true,
+    reason: `Natural boundary reached (${state.turnCount} turns, ${state.contextPercent}% context, completed phase/epic detected)`,
+  }
+}

--- a/tests/session-boundary.test.ts
+++ b/tests/session-boundary.test.ts
@@ -1,0 +1,69 @@
+import {
+  estimateContextPercent,
+  shouldCreateNewSession,
+} from "../src/lib/session-boundary.js"
+
+let passed = 0
+let failed_ = 0
+
+function assert(cond: boolean, name: string) {
+  if (cond) {
+    passed++
+    process.stderr.write(`  PASS: ${name}\n`)
+  } else {
+    failed_++
+    process.stderr.write(`  FAIL: ${name}\n`)
+  }
+}
+
+function testEstimateContextPercent() {
+  process.stderr.write("\n--- session-boundary: estimateContextPercent ---\n")
+
+  assert(estimateContextPercent(0, 20) === 0, "0 turns on threshold 20 => 0%")
+  assert(estimateContextPercent(10, 20) === 50, "10 turns on threshold 20 => 50%")
+  assert(estimateContextPercent(25, 20) === 100, "percent is capped at 100")
+  assert(estimateContextPercent(5, 0) === 100, "zero threshold is clamped safely")
+}
+
+function testShouldCreateNewSessionRules() {
+  process.stderr.write("\n--- session-boundary: shouldCreateNewSession ---\n")
+
+  const base = {
+    turnCount: 35,
+    contextPercent: 60,
+    hierarchyComplete: true,
+    isMainSession: true,
+    hasDelegations: false,
+  }
+
+  const nonMain = shouldCreateNewSession({ ...base, isMainSession: false })
+  assert(nonMain.recommended === false, "non-main session is excluded")
+
+  const withDelegations = shouldCreateNewSession({ ...base, hasDelegations: true })
+  assert(withDelegations.recommended === false, "delegation-active session is excluded")
+
+  const highContext = shouldCreateNewSession({ ...base, contextPercent: 80 })
+  assert(highContext.recommended === false, "context must be below 80%")
+
+  const lowTurns = shouldCreateNewSession({ ...base, turnCount: 29 })
+  assert(lowTurns.recommended === false, "turn threshold requires 30+")
+
+  const noBoundary = shouldCreateNewSession({ ...base, hierarchyComplete: false })
+  assert(noBoundary.recommended === false, "requires completed phase/epic boundary")
+
+  const recommended = shouldCreateNewSession(base)
+  assert(recommended.recommended === true, "recommends new session when all rules match")
+  assert(recommended.reason.includes("Natural boundary reached"), "recommendation reason is explicit")
+}
+
+function main() {
+  process.stderr.write("=== Session Boundary Tests ===\n")
+
+  testEstimateContextPercent()
+  testShouldCreateNewSessionRules()
+
+  process.stderr.write(`\n=== Session Boundary: ${passed} passed, ${failed_} failed ===\n`)
+  if (failed_ > 0) process.exit(1)
+}
+
+main()

--- a/tests/session-lifecycle-boundary.test.ts
+++ b/tests/session-lifecycle-boundary.test.ts
@@ -1,0 +1,82 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { initProject } from "../src/cli/init.js"
+import { createSessionLifecycleHook } from "../src/hooks/session-lifecycle.js"
+import { createTree, createNode, setRoot, saveTree } from "../src/lib/hierarchy-tree.js"
+import { createStateManager, loadConfig, saveConfig } from "../src/lib/persistence.js"
+
+let passed = 0
+let failed_ = 0
+
+function assert(cond: boolean, name: string) {
+  if (cond) {
+    passed++
+    process.stderr.write(`  PASS: ${name}\n`)
+  } else {
+    failed_++
+    process.stderr.write(`  FAIL: ${name}\n`)
+  }
+}
+
+async function testBoundaryWarningInjectedWhenConditionsAreMet() {
+  process.stderr.write("\n--- session-lifecycle: boundary warning injection ---\n")
+
+  const dir = await mkdtemp(join(tmpdir(), "hm-boundary-"))
+
+  try {
+    await initProject(dir, { governanceMode: "assisted", language: "en", silent: true })
+
+    const config = await loadConfig(dir)
+    await saveConfig(dir, {
+      ...config,
+      auto_compact_on_turns: 50,
+    })
+
+    const stateManager = createStateManager(dir)
+    const state = await stateManager.load()
+    if (!state) {
+      throw new Error("missing state after init")
+    }
+
+    state.metrics.turn_count = 35
+    state.session.role = "main"
+    state.cycle_log = []
+    await stateManager.save(state)
+
+    const root = createNode("trajectory", "Phase B complete", "complete")
+    const tree = setRoot(createTree(), root)
+    await saveTree(dir, tree)
+
+    const logger = {
+      debug: async (_message: string) => {},
+      info: async (_message: string) => {},
+      warn: async (_message: string) => {},
+      error: async (_message: string) => {},
+    }
+
+    const lifecycleConfig = await loadConfig(dir)
+    const hook = createSessionLifecycleHook(logger, dir, lifecycleConfig)
+    const output = { system: [] as string[] }
+
+    await hook({ sessionID: "test-session" }, output)
+
+    const text = output.system.join("\n")
+    assert(text.includes("🔄 Natural boundary reached"), "includes boundary recommendation line")
+    assert(text.includes("→ Run /hivemind-compact to archive and start fresh"), "includes compact handoff instruction")
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+async function main() {
+  process.stderr.write("=== Session Lifecycle Boundary Integration Tests ===\n")
+
+  await testBoundaryWarningInjectedWhenConditionsAreMet()
+
+  process.stderr.write(`\n=== Session Lifecycle Boundary: ${passed} passed, ${failed_} failed ===\n`)
+  if (failed_ > 0) process.exit(1)
+}
+
+await main()


### PR DESCRIPTION
## Summary
- Add session-boundary manager with context/turn heuristics and explicit recommendation reasons.
- Integrate boundary warnings into lifecycle prompt output.
- Extend messages-transform checklist with boundary recommendation item.
- Add non-disruptive SDK session creation after compact (non-fatal on failure).

## Validation
- `npm test`
- `npm run typecheck`

## Scope
- US-008, US-009, US-010, US-011 from `tasks/prd-phase-b.json`
- Stacked on Track A (`phase-b-track-a`) due messages-transform dependency