### PR TITLE
feat: improve 5 lowest-scoring skills via tessl review

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/context-first-gatekeeping/SKILL.md
+++ b/skills/context-first-gatekeeping/SKILL.md
@@ -1,99 +1,26 @@
 ---
-name: "context-first-gatekeeping"
-description: "The absolute gatekeeping factor for app development success. Context-first, never act without verified planning, unbroken hierarchy chains, and domain boundaries enforced."
-triggers:
-  - "Before ANY implementation action"
-  - "When starting a new task"
-  - "After context compaction"
-  - "When resuming from interrupted work"
-version: "1.0.0"
+name: context-first-gatekeeping
+description: "Enforce mandatory pre-implementation checks in HiveMind sessions — verify trajectory exists via scan_hierarchy, retrieve plans from recall_mems, validate domain boundaries, and check drift before allowing any code changes. Use when starting a new task, resuming interrupted work, after context compaction, or before any implementation action in a HiveMind session."
 ---
 
-<EXTREMELY-IMPORTANT>
-This is the absolute gatekeeping factor. NEVER ACT WITHOUT SUCCESS RETRIEVAL OF PLANNING.
-Skipping this gatekeeping is the #1 cause of app development failures.
-</EXTREMELY-IMPORTANT>
+# Context-First Gatekeeping
 
-# Context-First Gatekeeping Skill
+Blocks implementation until all context gates pass. Runs `scan_hierarchy`, `recall_mems`, `list_anchors`, and `think_back` to confirm the agent has verified planning, an unbroken hierarchy chain, acceptable drift, and valid domain boundaries.
 
-## The Prime Directive
+## Gatekeeping Checklist
 
-**NEVER ACT WITHOUT SUCCESS RETRIEVAL OF PLANNING**
+Run before ANY implementation action — if any check fails, stop and fix before proceeding:
 
-This is the absolute gatekeeping factor that determines whether app development succeeds or fails.
+1. **Trajectory exists?** — `scan_hierarchy({ action: "status" })` → if missing, run `declare_intent`
+2. **Tactic defined?** — hierarchy must have Level 2 → if missing, run `map_context({ level: "tactic" })`
+3. **Plan retrieved?** — `recall_mems({ query: "plan trajectory tactic" })` → must return results, never assume
+4. **Anchors loaded?** — `list_anchors()` → load constraints
+5. **Chain unbroken?** — `scan_hierarchy` confirms Trajectory → Tactic → Action chain
+6. **Drift acceptable?** — `think_back({ mode: "check" })` → must be < 60
+7. **Domain boundaries OK?** — files stay within allowed paths for their domain
+8. **No pending failures?** — `brain.metrics.failures` is clear
 
-## The Five Pillars
-
-### Pillar 1: Context-First Protocol
-
-**Before ANY action:**
-1. Load context (`scan_hierarchy`)
-2. Recall relevant memories (`recall_mems`)
-3. Check anchors for constraints (`list_anchors`)
-4. Verify chain integrity (`think_back`)
-
-**Pattern:**
-```
-LOAD → VERIFY → ACT
-```
-
-**NEVER:** Assume, guess, or "I think I remember..."
-
-### Pillar 2: Parent Hierarchy Must Exist
-
-**Unbroken chain requirement:**
-
-```
-Trajectory (Level 1)
-└── Tactic (Level 2)
-    └── Action (Level 3)
-```
-
-**Validation:**
-```typescript
-function validateHierarchy(): boolean {
-  const hierarchy = scan_hierarchy({ action: "status" })
-  
-  // Level 1: Trajectory must exist
-  if (!hierarchy.trajectory) {
-    throw new Error("NO TRAJECTORY - Use declare_intent first")
-  }
-  
-  // Level 2: Tactic must exist for actions
-  if (!hierarchy.tactic && isActionLevel()) {
-    throw new Error("NO TACTIC - Use map_context first")
-  }
-  
-  // Level 3: Chain must be unbroken
-  const ancestors = getAncestors()
-  if (ancestors.length < requiredLevel) {
-    throw new Error("BROKEN CHAIN - Repair with map_context")
-  }
-  
-  return true
-}
-```
-
-### Pillar 3: Never Act Without Verified Planning
-
-**Planning must be retrieved, not assumed:**
-
-```typescript
-// WRONG - Acting on assumption
-// "I remember we planned to do X, let me implement it"
-
-// RIGHT - Verifying planning exists
-const plan = recall_mems({ query: "plan trajectory tactic" })
-if (!plan || plan.length === 0) {
-  throw new Error("NO PLAN FOUND - Create plan before acting")
-}
-
-// THEN act based on verified plan
-```
-
-### Pillar 4: Domain Boundaries Enforced
-
-**Never cross domains without explicit approval:**
+## Domain Boundaries
 
 | Domain | Allowed Paths | Forbidden Paths |
 |--------|--------------|-----------------|
@@ -101,161 +28,36 @@ if (!plan || plan.length === 0) {
 | Frontend | `src/dashboard/`, `src/views/`, `src/components/` | `src/lib/`, `src/tools/`, `src/schemas/` |
 | Shared | `src/types/`, `src/utils/`, `tests/` | None (can cross) |
 
-**Validation:**
-```typescript
-function validateDomainBoundary(files: string[], domain: string): boolean {
-  const boundaries = DOMAIN_BOUNDARIES[domain]
-  
-  for (const file of files) {
-    const inAllowed = boundaries.allowed.some(p => file.startsWith(p))
-    const inForbidden = boundaries.forbidden.some(p => file.startsWith(p))
-    
-    if (!inAllowed || inForbidden) {
-      throw new Error(`DOMAIN VIOLATION: ${file} not in ${domain}`)
-    }
-  }
-  
-  return true
-}
-```
+Cross-domain changes require explicit user approval.
 
-### Pillar 5: Context-Purified State
+## Failure Escalation
 
-**After context compaction, NEVER trust memory:**
+| Level | Condition | Action |
+|-------|-----------|--------|
+| Auto-recoverable | Missing tactic, high drift | `map_context` or `think_back({ mode: "full" })` |
+| User guidance | No plan found, domain violation | Ask user to confirm plan or approve cross-domain |
+| Critical — stop | No trajectory, broken chain | Must `declare_intent` or manually repair hierarchy |
+
+## After Context Compaction
+
+Never trust memory after compaction. Reload everything:
 
 ```typescript
-// After compaction event
-if (justCompacted) {
-  // RELOAD everything
-  think_back({ mode: "full" })  // Reload context
-  recall_mems({ query: "recent" })  // Reload memories
-  list_anchors()  // Reload constraints
-  
-  // VERIFY chain still intact
-  validateHierarchy()
-}
-```
-
-## The Gatekeeping Checklist
-
-Before ANY implementation action:
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    GATEKEEPING CHECKLIST                     │
-├─────────────────────────────────────────────────────────────┤
-│  [ ] 1. Trajectory exists?         (declare_intent)         │
-│  [ ] 2. Tactic defined?            (map_context)            │
-│  [ ] 3. Plan retrieved from mems?  (recall_mems)            │
-│  [ ] 4. Anchors loaded?            (list_anchors)           │
-│  [ ] 5. Chain unbroken?            (scan_hierarchy)         │
-│  [ ] 6. Drift acceptable (<60)?    (think_back)             │
-│  [ ] 7. Domain boundaries OK?      (validateDomainBoundary) │
-│  [ ] 8. No pending failures?       (brain.metrics.failures) │
-└─────────────────────────────────────────────────────────────┘
-
-IF ANY CHECK FAILS → STOP, FIX BEFORE PROCEEDING
-```
-
-## Failure Escalation Protocol
-
-When a gate fails:
-
-### Level 1: Auto-Recoverable
-- Missing tactic → `map_context({ level: "tactic" })`
-- High drift → `think_back({ mode: "full" })`
-
-### Level 2: User Guidance Needed
-- No plan found → Ask user to provide/confirm plan
-- Domain violation → Ask user for cross-domain approval
-
-### Level 3: Critical - Stop Chain
-- No trajectory → Must `declare_intent` (new session)
-- Broken chain → Must manually repair hierarchy
-
-## Integration with Sequential Orchestration
-
-This skill is the **first step** in sequential-orchestration:
-
-```
-1. context-first-gatekeeping (THIS SKILL)
-   ↓ All gates pass
-2. sequential-orchestration
-   ↓ Sequential delegation
-3. export_cycle
-   ↓ Intelligence captured
-4. map_context
-   ↓ Hierarchy updated
-```
-
-## Red Flags - Immediate Stop
-
-| Red Flag | Meaning | Required Action |
-|----------|---------|-----------------|
-| "I think..." | Assumption, not verified | STOP, verify with recall_mems |
-| "Let me just..." | Bypassing gatekeeping | STOP, run gatekeeping checklist |
-| "Probably works" | No verification | STOP, run quality gates |
-| "I'll fix later" | Leaving broken chain | STOP, fix now before proceeding |
-| "Crossing to other domain" | Boundary violation | STOP, get approval or reroute |
-
-## Quick Commands
-
-```bash
-# Full gatekeeping check
-scan_hierarchy({ action: "status" })  # Check hierarchy
-think_back({ mode: "check" })          # Check drift
-recall_mems({ query: "plan" })         # Check planning
-list_anchors()                        # Check constraints
-
-# Repair broken chain
-map_context({ level: "tactic", content: "..." })
-map_context({ level: "action", content: "..." })
-
-# Context recovery
 think_back({ mode: "full" })
+recall_mems({ query: "recent" })
+list_anchors()
+// Then re-validate hierarchy
 ```
 
-## Gatekeeping Flow Diagram
+## Red Flags — Immediate Stop
 
-```dot
-digraph gatekeeping {
-    "Action Requested" [shape=doublecircle];
-    "Trajectory Exists?" [shape=diamond];
-    "Declare Intent" [shape=box];
-    "Tactic Defined?" [shape=diamond];
-    "Map Context" [shape=box];
-    "Plan Retrieved?" [shape=diamond];
-    "Recall Mems" [shape=box];
-    "Chain Unbroken?" [shape=diamond];
-    "Think Back" [shape=box];
-    "Drift OK?" [shape=diamond];
-    "Domain OK?" [shape=diamond];
-    "Get Approval" [shape=box];
-    "PROCEED" [shape=doublecircle, style=filled, fillcolor=green];
-    "STOP" [shape=doublecircle, style=filled, fillcolor=red];
+| Signal | Meaning | Action |
+|--------|---------|--------|
+| "I think..." | Unverified assumption | Verify with `recall_mems` |
+| "Let me just..." | Bypassing gates | Run full checklist |
+| "Probably works" | No verification | Run quality gates |
+| "I'll fix later" | Broken chain left open | Fix now |
 
-    "Action Requested" -> "Trajectory Exists?";
-    "Trajectory Exists?" -> "Declare Intent" [label="no"];
-    "Trajectory Exists?" -> "Tactic Defined?" [label="yes"];
-    "Declare Intent" -> "Tactic Defined?";
-    "Tactic Defined?" -> "Map Context" [label="no"];
-    "Tactic Defined?" -> "Plan Retrieved?" [label="yes"];
-    "Map Context" -> "Plan Retrieved?";
-    "Plan Retrieved?" -> "Recall Mems" [label="no"];
-    "Plan Retrieved?" -> "Chain Unbroken?" [label="yes"];
-    "Recall Mems" -> "Chain Unbroken?";
-    "Chain Unbroken?" -> "Think Back" [label="no"];
-    "Chain Unbroken?" -> "Drift OK?" [label="yes"];
-    "Think Back" -> "Drift OK?";
-    "Drift OK?" -> "Think Back" [label="no (>60)"];
-    "Drift OK?" -> "Domain OK?" [label="yes (<60)"];
-    "Domain OK?" -> "Get Approval" [label="no"];
-    "Domain OK?" -> "PROCEED" [label="yes"];
-    "Get Approval" -> "PROCEED" [label="approved"];
-    "Get Approval" -> "STOP" [label="denied"];
-}
-```
+## Integration
 
----
-
-*This skill is a companion to `hivemind-governance` and must be loaded BEFORE any implementation work begins.*
+This skill runs **first** in the sequential-orchestration pipeline: gatekeeping → sequential-orchestration → export_cycle → map_context.

--- a/skills/debug-orchestration/SKILL.md
+++ b/skills/debug-orchestration/SKILL.md
@@ -1,304 +1,72 @@
-# Skill: debug-orchestration
+---
+name: debug-orchestration
+description: "Coordinate multi-phase debugging sessions in HiveMind by routing LSP errors, test failures, and manual /debug triggers through event capture, context preservation, strategy selection, and resolution. Use when setting up automated debug responses, orchestrating complex debug workflows across sessions, or building debug automation pipelines with HiveMind swarm agents."
+---
 
-## Overview
+# Debug Orchestration
 
-This skill provides the **high-level orchestration framework** for debugging in HiveMind v3.0. It coordinates systematic debugging, parallel debugging, and event-driven LSP hooks into a unified workflow.
+Coordinates the full debugging lifecycle — from event detection through resolution — using HiveMind sessions, anchors, memory, and swarm agents. Selects between systematic and parallel debugging strategies based on issue characteristics.
 
-## Core Principle
+## Workflow
+
+1. **Detect event** — capture LSP diagnostics, test failures, runtime errors, or manual `/debug` invocations
+2. **Preserve context** — start a `hivemind_session` in `quick_fix` mode, save pre-debug state via `hivemind_anchor`
+3. **Select strategy** — route to `systematic-debugging-hivemind` (reproducible/obvious) or `parallel-debugging-hivemind` (multiple plausible causes)
+4. **Execute debug loop** — gather evidence, form hypothesis, test, verify; check drift with `hivemind_inspect`
+5. **Resolve** — run `npm test && npx tsc --noEmit`, save solution to memory, cleanup anchors, export cycle
+
+## Strategy Selection
 
 ```
-DEBUGGING IS AN ORCHESTRATION, NOT A SEQUENCE
+Reproducible?
+├── YES → Obvious root cause?
+│   ├── YES → systematic-debugging-hivemind
+│   └── NO  → parallel-debugging-hivemind
+└── NO  → systematic-debugging-hivemind + extended evidence
 ```
 
-This skill instructs the Agent on HOW to orchestrate the entire debugging lifecycle using commands, skills, and agents.
+## Event Hooks
 
-## When to Use
+Register in `src/hooks/event-handler.ts`:
 
-Activate this skill when:
-- Setting up automated debug responses to LSP/test events
-- Orchestrating complex multi-phase debug sessions
-- Managing debug workflows that span multiple sessions
-- Building debug automation pipelines
-
-## The Orchestration Framework
-
-### Layer 1: Event Detection (The Strike)
-
-**Trigger Sources:**
-- LSP diagnostics (`lsp.diagnostics.publish`)
-- Test failures (`npm test` fails)
-- Runtime errors (caught by hooks)
-- Manual invocation (`/debug` command)
-
-**Step 1.1: Capture the Event**
 ```typescript
-// Event hook triggers
-"event": async (event) => {
+// LSP diagnostics trigger
+"event": async ({ event }) => {
   if (event.type === "lsp.diagnostics.publish") {
-    // Extract diagnostic info
-    const { file, errors } = event.data
-    // Queue for investigation
+    const errors = event.data.diagnostics.filter(d => d.severity === 1)
+    if (errors.length > 0) await triggerDebugOrchestration({ source: "lsp", errors, file: event.data.uri })
   }
 }
 ```
 
-**Step 1.2: Classify the Event**
-```typescript
-const eventClassification = {
-  severity: "error|warning|hint",
-  category: "syntax|type|runtime|test",
-  source: "lsp|test|manual",
-  actionable: true | false
-}
-```
+Test failures and manual `/debug` commands follow the same pattern — see `src/hooks/event-handler.ts` and `commands/debug.ts`.
 
-### Layer 2: Context Preservation (The Anchor)
-
-**Step 2.1: Snapshot Current State**
-```typescript
-// Before debugging, preserve context
-hivemind_session({
-  action: "start",
-  mode: "quick_fix",
-  focus: "Debug: [event_summary]"
-})
-
-// Save current state
-hivemind_anchor({
-  action: "save",
-  key: "pre_debug_state",
-  value: JSON.stringify(stateSnapshot)
-})
-```
-
-**Step 2.2: Establish Debug Boundary**
-```typescript
-// Mark where debugging starts
-hivemind_memory({
-  action: "save",
-  shelf: "debug_sessions",
-  content: `Debug session started: ${timestamp}`,
-  tags: "debug,started"
-})
-```
-
-### Layer 3: Strategy Selection
-
-**Decision Tree:**
-
-```
-Is the issue reproducible?
-├── YES → Is the root cause obvious?
-│   ├── YES → Use systematic-debugging-hivemind
-│   └── NO → Use parallel-debugging-hivemind
-└── NO → Use systematic-debugging-hivemind + extended evidence gathering
-```
-
-**Step 3.1: Select Strategy**
-```typescript
-const strategy = selectDebugStrategy({
-  reproducible: boolean,
-  obvious: boolean,
-  complexity: "low|medium|high",
-  timeConstraint: "urgent|normal|exploratory"
-})
-```
-
-### Layer 4: Execution
-
-**Step 4.1: Inject Skills**
-```typescript
-// Based on strategy, inject appropriate skills
-const skillsToInject = [
-  "systematic-debugging-hivemind",  // Always
-  // Plus based on strategy:
-  "parallel-debugging-hivemind",     // If parallel selected
-  "evidence-discipline"               // If verification critical
-]
-```
-
-**Step 4.2: Execute Debug Loop**
-```typescript
-while (!resolved && attempts < maxAttempts) {
-  // Gather evidence
-  // Form hypothesis
-  // Test hypothesis
-  // Verify fix
-  
-  // If stuck:
-  // Call hivemind_inspect({ action: "drift" })
-  // If drift < 40: compact_session and continue
-}
-```
-
-### Layer 5: Resolution
-
-**Step 5.1: Verify Complete**
-```typescript
-// Run verification suite
-await bash({ command: "npm test && npx tsc --noEmit" })
-
-// Check no regressions
-```
-
-**Step 5.2: Document Solution**
-```typescript
-hivemind_memory({
-  action: "save",
-  shelf: "solutions",
-  content: `
-Root Cause: [X]
-Symptoms: [Y]
-Fix Applied: [Z]
-Verification: [W]
-  `,
-  tags: "debug,resolved,[category]"
-})
-```
-
-**Step 5.3: Cleanup**
-```typescript
-// Remove debug anchors
-hivemind_anchor({ action: "delete", key: "pre_debug_state" })
-
-// Export cycle
-hivemind_cycle({ action: "export" })
-```
-
-## Event-Driven Debug Automation
-
-### LSP Diagnostics Hook
+## Context Preservation
 
 ```typescript
-// In src/hooks/event-handler.ts
-export const LSPDiagnosticsHook = {
-  "event": async ({ event, client }) => {
-    if (event.type !== "lsp.diagnostics.publish") return
-    
-    const diagnostics = event.data.diagnostics
-    const errors = diagnostics.filter(d => d.severity === 1)
-    
-    if (errors.length > 0) {
-      // Trigger debug orchestration
-      await triggerDebugOrchestration({
-        source: "lsp",
-        errors,
-        file: event.data.uri
-      })
-    }
-  }
-}
+hivemind_session({ action: "start", mode: "quick_fix", focus: "Debug: [event_summary]" })
+hivemind_anchor({ action: "save", key: "pre_debug_state", value: JSON.stringify(stateSnapshot) })
 ```
 
-### Test Failure Hook
+## Resolution Checklist
 
-```typescript
-// In src/hooks/event-handler.ts
-export const TestFailureHook = {
-  "event": async ({ event }) => {
-    if (event.type !== "test.failed") return
-    
-    // Capture test output
-    const testOutput = event.data.output
-    
-    // Trigger debug orchestration
-    await triggerDebugOrchestration({
-      source: "test",
-      errors: parseTestFailures(testOutput),
-      testFile: event.data.file
-    })
-  }
-}
-```
-
-### Manual Debug Command
-
-```typescript
-// In commands/debug.ts
-export const debugCommand = {
-  name: "debug",
-  description: "Trigger debug orchestration for a specific issue",
-  
-  async execute(args) {
-    return triggerDebugOrchestration({
-      source: "manual",
-      issue: args.issue,
-      context: args.context
-    })
-  }
-}
-```
-
-## Debug Session Lifecycle
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     EVENT DETECTED                           │
-│  (LSP error / Test failure / Manual trigger)                │
-└──────────────────────────┬──────────────────────────────────┘
-                           │
-                           ▼
-┌─────────────────────────────────────────────────────────────┐
-│                  CONTEXT PRESERVATION                        │
-│  - Snapshot state via hivemind_anchor                       │
-│  - Start debug session via hivemind_session                  │
-│  - Create debug boundary in memory                          │
-└──────────────────────────┬──────────────────────────────────┘
-                           │
-                           ▼
-┌─────────────────────────────────────────────────────────────┐
-│                  STRATEGY SELECTION                          │
-│  - Reproducible? Obvious?                                   │
-│  - Select: systematic / parallel / extended                 │
-└──────────────────────────┬──────────────────────────────────┘
-                           │
-                           ▼
-┌─────────────────────────────────────────────────────────────┐
-│                      EXECUTION                               │
-│  - Inject skills                                            │
-│  - Debug loop: gather → hypothesize → test → verify         │
-│  - Check drift, compact if needed                           │
-└──────────────────────────┬──────────────────────────────────┘
-                           │
-                           ▼
-┌─────────────────────────────────────────────────────────────┐
-│                    RESOLUTION                               │
-│  - Verify fix                                               │
-│  - Document solution                                        │
-│  - Cleanup anchors                                          │
-│  - Export cycle                                             │
-└─────────────────────────────────────────────────────────────┘
-```
-
-## Pre-Flight Checklist (BEFORE Output)
-
-- [ ] Did I establish debug session with hivemind_session?
-- [ ] Did I preserve pre-debug state?
-- [ ] Did I select appropriate strategy?
-- [ ] Did I inject required skills?
-- [ ] Did I execute verification before claiming success?
-- [ ] Did I save solution to memory?
-- [ ] Did I cleanup anchors?
-- [ ] Did I call export_cycle?
+- [ ] Debug session started with `hivemind_session`
+- [ ] Pre-debug state preserved via anchor
+- [ ] Strategy selected and skills injected
+- [ ] Verification passed (`npm test && npx tsc --noEmit`)
+- [ ] Solution saved to `hivemind_memory` shelf `solutions`
+- [ ] Debug anchors cleaned up
+- [ ] Cycle exported via `hivemind_cycle`
 
 ## Constraints
 
-1. **Never skip evidence gathering** - Always gather before fixing
-2. **Never assume** - Verify each hypothesis
-3. **Never ignore drift** - Check context integrity regularly
-4. **Always document** - Save solutions to memory
-5. **Always cleanup** - Remove debug artifacts
-
-## Related Skills
-
-- `systematic-debugging-hivemind`: Single-hypothesis debugging
-- `parallel-debugging-hivemind`: Multi-hypothesis debugging
-- `hivemind-governance`: Session and context management
-- `evidence-discipline`: Verification requirements
+- Never skip evidence gathering — always gather before fixing
+- Never assume — verify each hypothesis
+- Check drift regularly with `hivemind_inspect({ action: "drift" })`; compact if drift < 40
 
 ## File References
 
-- **Event hooks**: `src/hooks/event-handler.ts`
-- **Swarm orchestration**: `src/lib/session-swarm.ts`
-- **Debug commands**: `commands/debug.ts`
-- **State management**: `src/lib/persistence.ts`
+- `src/hooks/event-handler.ts` — event hooks
+- `src/lib/session-swarm.ts` — swarm orchestration
+- `commands/debug.ts` — manual debug command
+- `src/lib/persistence.ts` — state management

--- a/skills/hivefiver-bilingual-tutor/SKILL.md
+++ b/skills/hivefiver-bilingual-tutor/SKILL.md
@@ -1,35 +1,38 @@
 ---
 name: hivefiver-bilingual-tutor
-description: Deliver HiveFiver v2 onboarding and instruction in EN/VI with equivalent structure, examples, and validation gates.
+description: "Generate HiveFiver onboarding content and instructional outputs in English, Vietnamese, or bilingual mode with mirrored structure, preserved technical terms, and validation gates. Use when onboarding new team members, explaining HiveFiver workflows in EN or VI, creating bilingual documentation, or delivering instructional content for dev, marketing, finance, or operations teams."
 ---
 
 # HiveFiver Bilingual Tutor
 
-Use this skill for onboarding, explanation, and instructional outputs.
+Produces onboarding and instructional content in English, Vietnamese, or side-by-side bilingual format. Maintains equivalent structure, examples, and gate semantics across both languages while preserving technical terms untranslated.
 
 ## Workflow
-1. Detect preferred language (`en`, `vi`, `bilingual`).
-2. Keep structure and gate semantics equivalent across languages.
-3. Preserve technical terms (UUID, JSON, FK, MCP, TDD).
-4. Provide short examples per critical instruction.
-5. Track tutoring attempts and adaptive hints (up to 10).
+
+1. **Detect language** — determine user preference: `en`, `vi`, or `bilingual`; see `scripts/select-language.sh`
+2. **Generate content** — use `templates/bilingual-output.md` as the output scaffold
+3. **Preserve technical terms** — keep UUID, JSON, FK, MCP, TDD, and domain terms untranslated
+4. **Mirror structure** — tab layout, section order, and gate semantics must match across EN/VI
+5. **Add glossary** — emit bilingual glossary from `references/terminology-en-vi.md` when domain-heavy terms appear
+6. **Validate output** — confirm no constraints dropped in translation; track tutoring attempts (up to 10 adaptive hints)
 
 ## Coverage
-- Dev workflows
-- Marketing workflows
-- Finance workflows
-- Office/operations workflows
+
+| Domain | Examples |
+|--------|----------|
+| Dev workflows | TDD cycles, code review gates, CI/CD setup |
+| Marketing workflows | Campaign briefs, content calendars |
+| Finance workflows | Budget templates, reporting gates |
+| Office/operations | Process checklists, onboarding sequences |
 
 ## Output Rules
-- Mirror tab layout across EN/VI.
-- Avoid dropping constraints in translated output.
-- Emit bilingual glossary when domain-heavy terms appear.
 
-## References
-- `references/terminology-en-vi.md`
+- Mirror tab layout identically across EN and VI
+- Never drop constraints or gates in translated output
+- Emit bilingual glossary when domain-heavy terms appear for the first time
 
-## Template
-- `templates/bilingual-output.md`
+## Bundle Files
 
-## Script
-- `scripts/select-language.sh`
+- `references/terminology-en-vi.md` — EN/VI term mappings
+- `templates/bilingual-output.md` — output structure template
+- `scripts/select-language.sh` — language detection script

--- a/skills/parallel-debugging-hivemind/SKILL.md
+++ b/skills/parallel-debugging-hivemind/SKILL.md
@@ -1,203 +1,62 @@
-# Skill: parallel-debugging-hivemind
+---
+name: parallel-debugging-hivemind
+description: "Run multiple debugging hypotheses simultaneously using HiveMind headless swarm agents via spawnHeadlessResearcher. Use when multiple plausible root causes exist, single-threaded debugging is too slow, testing different environment configurations, or investigating non-deterministic and timing-dependent bugs."
+---
 
-## Overview
+# Parallel Debugging HiveMind
 
-This skill provides the **parallel debugging methodology** for HiveMind v3.0. It instructs agents on how to run multiple debugging hypotheses simultaneously using headless swarm agents.
+Orchestrates concurrent hypothesis testing by spawning headless swarm agents, each focused on a single root-cause theory. Agents run independently and report back via `hivemind_cycle`, then results are synthesized to identify the confirmed fix.
 
-## Core Principle
+## Workflow
 
-```
-WHEN ONE HYPOTHESIS IS UNCERTAIN, TEST MULTIPLE IN PARALLEL
-```
+1. **Enumerate hypotheses** — list 2-5 plausible causes with supporting evidence, rank by likelihood and testability
+2. **Configure swarm** — assign each hypothesis to a dedicated agent with `systematic-debugging-hivemind` injected and clear success/failure criteria
+3. **Spawn agents** — use `spawnHeadlessResearcher` from `src/lib/session-swarm.ts`
+4. **Monitor** — check status with `hivemind_inspect({ action: "scan" })`
+5. **Synthesize** — collect results via `hivemind_cycle({ action: "export" })`, pick confirmed hypothesis, implement fix
 
-This skill DOES NOT execute code. It instructs the Agent on HOW to orchestrate parallel debugging using HiveMind swarm capabilities.
+## Spawning a Swarm Agent
 
-## When to Use
-
-Activate this skill when:
-- Multiple plausible root causes exist
-- Single-threaded debugging is too slow
-- You need to test different environmental configurations
-- The bug is non-deterministic or timing-dependent
-
-## The Parallel Debugging Workflow
-
-### Phase 1: Enumerate Hypotheses
-
-**Step 1.1: List All Possible Causes**
-```
-Based on evidence gathered:
-1. Hypothesis A: [cause] - because [evidence]
-2. Hypothesis B: [cause] - because [evidence]
-3. Hypothesis C: [cause] - because [evidence]
-```
-
-**Step 1.2: Prioritize**
-- Rank by likelihood
-- Rank by ease of testing
-- Identify which can run in parallel
-
-### Phase 2: Prepare Swarm Agents
-
-**Step 2.1: Create Swarm Configuration**
 ```typescript
-// Each swarm agent gets:
-// - Unique focus (one hypothesis)
-// - systematic-debugging-hivemind skill injected
-// - Limited scope (test just this hypothesis)
-
-const swarmConfig = {
-  agents: [
-    { id: "debug-A", focus: "Test hypothesis A: [specific cause]" },
-    { id: "debug-B", focus: "Test hypothesis B: [specific cause]" },
-    { id: "debug-C", focus: "Test hypothesis C: [specific cause]" }
-  ],
-  coordination: "parallel"
-}
-```
-
-**Step 2.2: Prepare Each Agent**
-Each swarm agent should:
-- Receive the systematic-debugging-hivemind skill
-- Have clear success/failure criteria
-- Report back via hivemind_cycle
-
-### Phase 3: Execute Parallel Testing
-
-**Step 3.1: Spawn Headless Researchers**
-```typescript
-// Use session-swarm.ts to spawn
 import { spawnHeadlessResearcher } from "src/lib/session-swarm"
 
 await spawnHeadlessResearcher({
   taskId: "debug-A",
   focus: "Verify hypothesis A",
-  context: {
-    hypothesis: "...",
-    testMethod: "...",
-    successCriteria: "..."
-  }
+  context: { hypothesis: "...", testMethod: "...", successCriteria: "..." }
 })
 ```
 
-**Step 3.2: Monitor Progress**
-```typescript
-// Check swarm status
-hivemind_inspect({ action: "scan" })
-```
+## Parallel Patterns
 
-**Step 3.3: Collect Results**
-```typescript
-// Each agent calls export_cycle when done
-hivemind_cycle({ action: "export" })
-```
+| Pattern | When to Use | Example |
+|---------|-------------|---------|
+| Environment variation | Bug appears in some Node versions | Spawn agents for Node 18, 20, 22 |
+| Dependency version | Regression after upgrade | Test with dependency v1 vs v2 |
+| State variation | State-dependent failures | Test from clean, loaded, compacted states |
+| Race condition | Non-deterministic bugs | Multiple agents attempting to trigger concurrently |
 
-### Phase 4: Synthesize Results
+## Coordination
 
-**Step 4.1: Analyze All Findings**
-- Which hypotheses were confirmed?
-- Which were disproven?
-- Any unexpected findings?
-
-**Step 4.2: Determine Winner**
-- Choose the confirmed hypothesis
-- If none confirmed → return to Phase 1 with new information
-
-**Step 4.3: Implement Fix**
-- Apply fix for confirmed root cause
-- Verify with test suite
-
-## HiveMind-Specific Parallel Patterns
-
-### Pattern 1: Environment Variation Testing
-
-Run same test across different environments:
-
-```typescript
-const envSwarm = [
-  { id: "env-node18", env: { node: "18" }, focus: "Test with Node 18" },
-  { id: "env-node20", env: { node: "20" }, focus: "Test with Node 20" },
-  { id: "env-node22", env: { node: "22" }, focus: "Test with Node 22" }
-]
-```
-
-### Pattern 2: Dependency Version Testing
-
-Test with different dependency versions:
-
-```typescript
-const depSwarm = [
-  { id: "dep-v1", focus: "Test with dependency v1" },
-  { id: "dep-v2", focus: "Test with dependency v2" }
-]
-```
-
-### Pattern 3: State Variation Testing
-
-Test from different session states:
-
-```typescript
-const stateSwarm = [
-  { id: "state-clean", setup: "clean state", focus: "Test from clean state" },
-  { id: "state-loaded", setup: "loaded state", focus: "Test from loaded state" },
-  { id: "state-compacted", setup: "compacted state", focus: "Test from compacted state" }
-]
-```
-
-### Pattern 4: Race Condition Detection
-
-Run multiple agents trying to trigger the same bug:
-
-```typescript
-const raceSwarm = [
-  { id: "race-1", focus: "Attempt to trigger race condition - try 1" },
-  { id: "race-2", focus: "Attempt to trigger race condition - try 2" },
-  { id: "race-3", focus: "Attempt to trigger race condition - try 3" }
-]
-```
-
-## Coordination Mechanisms
-
-### Method 1: Broadcast Channel
-```typescript
-// All agents share findings via graph/mems.json
-hivemind_memory({ action: "save", shelf: "debug-results", content: "..." })
-```
-
-### Method 2: Aggregation Agent
-```typescript
-// One agent collects all results
-// Analyzes and synthesizes findings
-```
-
-### Method 3: First-Winner Stops Others
-```typescript
-// If any agent confirms hypothesis first
-// Other agents stop and report status
-```
-
-## Pre-Flight Checklist (BEFORE Output)
-
-- [ ] Did I enumerate at least 2-3 hypotheses?
-- [ ] Did I assign each hypothesis to a separate agent?
-- [ ] Did I define clear success/failure criteria?
-- [ ] Did I set up communication mechanism between agents?
-- [ ] Did I prepare aggregation/synthesis step?
+- **Broadcast** — agents share findings via `hivemind_memory({ shelf: "debug-results" })` in `graph/mems.json`
+- **First-winner** — first agent to confirm a hypothesis signals others to stop
+- **Aggregation** — one agent collects and synthesizes all results
 
 ## Constraints
 
-- **MAX 5 parallel agents** (to prevent resource exhaustion)
-- **Each agent must report back** via `hivemind_cycle({ action: "export" })`
-- **If no hypothesis confirmed after 3 cycles**, STOP and question the architecture
+- Maximum 5 parallel agents to prevent resource exhaustion
+- Each agent must report back via `hivemind_cycle({ action: "export" })`
+- If no hypothesis confirmed after 3 cycles, stop and re-evaluate assumptions
 
-## Related Skills
+## Checklist
 
-- `systematic-debugging-hivemind`: For single-hypothesis testing
-- `debug-orchestration`: For orchestrating complex debug sessions
-- `hivemind-governance`: For session management during parallel debugging
+- [ ] At least 2-3 hypotheses enumerated with evidence
+- [ ] Each hypothesis assigned to a separate agent
+- [ ] Clear success/failure criteria defined per agent
+- [ ] Communication mechanism configured (broadcast, first-winner, or aggregation)
 
 ## File References
 
-- **Swarm spawning**: `src/lib/session-swarm.ts`
-- **Memory sharing**: `graph/mems.json`
-- **State coordination**: `.hivemind/state/`
+- `src/lib/session-swarm.ts` — swarm spawning
+- `graph/mems.json` — shared memory
+- `.hivemind/state/` — state coordination

--- a/skills/systematic-debugging-hivemind/SKILL.md
+++ b/skills/systematic-debugging-hivemind/SKILL.md
@@ -1,222 +1,64 @@
-# Skill: systematic-debugging-hivemind
+---
+name: systematic-debugging-hivemind
+description: "Debug HiveMind issues methodically by gathering evidence, investigating root causes, forming hypotheses, and verifying fixes using hivemind_session, hivemind_memory, and hivemind_inspect commands. Use when npm test fails, LSP diagnostics report errors, runtime errors occur, or hooks and commands behave unexpectedly."
+---
 
-## Overview
+# Systematic Debugging HiveMind
 
-This skill provides the **systematic debugging methodology** specifically adapted for the HiveMind v3.0 Relational Cognitive Engine. It instructs agents on HOW to debug using HiveMind-specific commands and hooks.
+Single-hypothesis debugging methodology for HiveMind. Enforces evidence-first investigation before any fix attempt using HiveMind-specific commands in a strict sequence.
 
-## Core Principle
+## Workflow
 
-```
-NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
-```
+1. **Gather evidence** — start `hivemind_session({ action: "start", mode: "quick_fix" })`, capture error output, identify scope with `grep`
+2. **Investigate root cause** — check known solutions via `hivemind_memory({ action: "recall", shelf: "solutions" })`, check anchors, analyze drift with `hivemind_inspect({ action: "drift" })`
+3. **Form hypothesis** — state root cause with supporting evidence, create minimal reproduction
+4. **Fix and verify** — write a failing test first (`npm test -- --grep "<name>"`), apply ONE minimal change, verify with `npm test && npx tsc --noEmit`
+5. **Save solution** — persist to `hivemind_memory({ shelf: "solutions", tags: "debug,bugfix,[category]" })`
 
-This skill DOES NOT execute code. It instructs the Agent on WHICH Commands to use and in WHAT sequence.
+## Debugging Patterns
 
-## When to Use
+### Hook Debugging (`src/hooks/*.ts`)
 
-Activate this skill when:
-- Test failures occur (`npm test` fails)
-- LSP diagnostics publish errors
-- Runtime errors in production
-- Unexpected behavior in hooks or commands
+1. Read hook index: `read({ filePath: "src/hooks/index.ts" })`
+2. Verify event binding: `grep({ include: "*.ts", pattern: "experimental\\..*\\.transform" })`
+3. Test manually: `node bin/hivemind-tools.cjs session trace <timestamp>`
 
-## The Debugging Phases
+### Command Debugging (`bin/hivemind-tools.cjs`)
 
-### Phase 1: Evidence Gathering (Command: read, glob, grep)
+1. Check implementation: `read({ filePath: "src/lib/[command].ts" })`
+2. Test in isolation: `node bin/hivemind-tools.cjs [command] --help`
 
-**Step 1.1: Capture the Failure Signal**
-```typescript
-// Use hivemind_session to establish debug context
-hivemind_session({
-  action: "start",
-  mode: "quick_fix",
-  focus: "Debug [specific error]"
-})
-```
+### Session/State Debugging
 
-**Step 1.2: Read the Error Output**
-- For test failures: Run `npm test` and capture full output
-- For LSP errors: Read the diagnostic file
-- For runtime errors: Capture stack trace
+1. Inspect state: `hivemind_inspect({ action: "scan" })`
+2. Check hierarchy: `scan_hierarchy({ action: "status" })`
+3. Review memory: `hivemind_memory({ action: "recall", limit: 10 })`
 
-**Step 1.3: Identify the Scope**
-```typescript
-// Determine affected files via grep
-grep({ include: "*.ts", pattern: "<error_keyword>" })
-```
+### Test Suite Debugging
 
-### Phase 2: Root Cause Investigation (Command: scan_hierarchy, recall_mems)
+1. Run single test: `npm test -- --grep "<test_name>"`
+2. Watch mode: `npm test -- --watch`
+3. Find test files: `glob({ pattern: "tests/**/*.test.ts" })`
 
-**Step 2.1: Check for Known Solutions**
-```typescript
-// Recall from memory
-hivemind_memory({
-  action: "recall",
-  query: "[error pattern]",
-  shelf: "solutions"
-})
+## Red Flags — Stop and Return to Evidence Gathering
 
-// Check anchors
-hivemind_anchor({ action: "list" })
-```
-
-**Step 2.2: Analyze Context Drift**
-```typescript
-// Check if debugging is compromised by stale context
-hivemind_inspect({ action: "drift" })
-```
-
-**Step 2.3: Trace the Data Flow**
-- Identify where the bad value originates
-- Trace up the call stack to find source
-- Use `grep` to find all references
-
-### Phase 3: Hypothesis Formation (Agent Reasoning)
-
-**Step 3.1: State the Hypothesis**
-```
-"I believe [X] is the root cause because [Y evidence]"
-```
-
-**Step 3.2: Isolate the Problem**
-- Create minimal reproduction
-- Test in isolation
-
-### Phase 4: Verification & Fix (Command: write, bash)
-
-**Step 4.1: Create Failing Test First**
-```bash
-npm test -- --grep "<test_name>"
-```
-
-**Step 4.2: Apply Minimal Fix**
-- ONE change at a time
-- No "while I'm here" improvements
-
-**Step 4.3: Verify**
-```bash
-npm test
-npx tsc --noEmit
-```
-
-**Step 4.4: Save to Memory**
-```typescript
-hivemind_memory({
-  action: "save",
-  shelf: "solutions",
-  content: "Root cause: [X], Fix: [Y]",
-  tags: "debug,bugfix,[category]"
-})
-```
-
-## HiveMind-Specific Debugging Patterns
-
-### Pattern 1: Hook Debugging
-
-When debugging hooks (`src/hooks/*.ts`):
-
-1. **Check Hook Registration**
-```typescript
-// Read the hook index
-read({ filePath: "src/hooks/index.ts" })
-```
-
-2. **Verify Event Binding**
-```typescript
-// Look for the hook registration pattern
-grep({ include: "*.ts", pattern: "experimental\\..*\\.transform" })
-```
-
-3. **Test with Minimal Input**
-```bash
-# Trigger the hook manually
-node bin/hivemind-tools.cjs session trace <timestamp>
-```
-
-### Pattern 2: Command Debugging
-
-When debugging commands (`bin/hivemind-tools.cjs`):
-
-1. **Verify Command Exists**
-```bash
-ls bin/
-```
-
-2. **Check Command Implementation**
-```typescript
-read({ filePath: "src/lib/[command].ts" })
-```
-
-3. **Test Command in Isolation**
-```bash
-node bin/hivemind-tools.cjs [command] --help
-```
-
-### Pattern 3: Session/State Debugging
-
-When debugging state management:
-
-1. **Inspect Current State**
-```typescript
-hivemind_inspect({ action: "scan" })
-```
-
-2. **Check Hierarchy Integrity**
-```typescript
-scan_hierarchy({ action: "status" })
-```
-
-3. **Review Recent Memory**
-```typescript
-hivemind_memory({ action: "recall", limit: 10 })
-```
-
-### Pattern 4: Test Suite Debugging
-
-When debugging test failures:
-
-1. **Run Single Test**
-```bash
-npm test -- --grep "<test_name>"
-```
-
-2. **Run in Watch Mode**
-```bash
-npm test -- --watch
-```
-
-3. **Check Test File Structure**
-```typescript
-glob({ pattern: "tests/**/*.test.ts" })
-```
-
-## Pre-Flight Checklist (BEFORE Output)
-
-- [ ] Did I call `hivemind_session({ action: "start" })` first?
-- [ ] Did I gather evidence before proposing fixes?
-- [ ] Did I check memory for known solutions?
-- [ ] Did I verify the hypothesis with minimal test?
-- [ ] Did I save the solution to memory?
-
-## Red Flags - STOP
-
-If you catch yourself thinking:
 - "Quick fix for now, investigate later"
 - "Just try changing X and see if it works"
 - "I think X is probably the cause"
 
-**ALL of these mean: STOP. Return to Phase 1.**
+Any of these means you are skipping evidence. Return to step 1.
 
-## Related Skills
+## Checklist
 
-- `parallel-debugging-hivemind`: For concurrent hypothesis testing
-- `debug-orchestration`: For orchestrating multiple debug agents
-- `hivemind-governance`: For maintaining context during long debug sessions
-- `evidence-discipline`: For verification requirements
+- [ ] Debug session started with `hivemind_session`
+- [ ] Evidence gathered before proposing fixes
+- [ ] Known solutions checked via `hivemind_memory`
+- [ ] Hypothesis verified with minimal test
+- [ ] Solution saved to memory
 
 ## File References
 
-- **Hook patterns**: `src/hooks/*.ts`
-- **Command patterns**: `bin/hivemind-tools.cjs`, `src/lib/*.ts`
-- **State patterns**: `.hivemind/state/`, `graph/*.json`
-- **Test patterns**: `tests/**/*.test.ts`
+- `src/hooks/*.ts` — hook patterns
+- `bin/hivemind-tools.cjs`, `src/lib/*.ts` — command patterns
+- `.hivemind/state/`, `graph/*.json` — state patterns
+- `tests/**/*.test.ts` — test patterns


### PR DESCRIPTION
Hey @shynlee04 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/36c7f604-38d4-4f02-b1f2-5b62c7f3f1a4" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| debug-orchestration | 0% | 85% | +85% |
| parallel-debugging-hivemind | 0% | 85% | +85% |
| systematic-debugging-hivemind | 0% | 100% | +100% |
| context-first-gatekeeping | 31% | 89% | +58% |
| hivefiver-bilingual-tutor | 32% | 81% | +49% |

The three 0% skills (debug-orchestration, parallel-debugging-hivemind, systematic-debugging-hivemind) were missing YAML frontmatter entirely, which caused deterministic validation to fail before the LLM judge could even run. The other two had vague descriptions lacking specificity, trigger terms, and "Use when..." clauses.

<details>
<summary>Changes made</summary>

- **Added YAML frontmatter** to 3 skills that had none (debug-orchestration, parallel-debugging-hivemind, systematic-debugging-hivemind) — this was the #1 blocker for scoring
- **Rewrote descriptions** across all 5 skills with specific concrete actions, natural trigger terms, and explicit "Use when..." clauses
- **Improved content structure** — replaced verbose prose with concise workflow steps, tables, and checklists
- **Trimmed redundancy** — removed duplicate explanations, overly long code blocks, and repeated "Core Principle" sections
- **Preserved domain expertise** — kept all HiveMind-specific commands (hivemind_session, hivemind_memory, hivemind_inspect, etc.), file references, and debugging patterns intact
- **Removed unknown frontmatter keys** (triggers, version) from context-first-gatekeeping that were causing warnings
</details>

This PR intentionally caps at 5 skills to keep the review manageable. The repo has 19 skills total — the included GitHub Action workflow (next commit) will surface Tessl feedback on every future PR that touches `SKILL.md`, so the rest of the library can improve incrementally.

<details>
<summary>🤖 Tessl Skill Review GitHub Action — what it does</summary>

This PR also adds `.github/workflows/skill-review.yml` which:

- **Runs automatically** on PRs that change any `**/SKILL.md` file, using [`tesslio/skill-review`](https://github.com/tesslio/skill-review) to post **one** PR comment with Tessl scores and feedback (updated on new pushes)
- **Zero extra accounts** — contributors do **not** need a Tessl login; only the repo's default `GITHUB_TOKEN` is used to post the comment
- **Non-blocking by default** — the check is feedback-only with no surprise red CI. You can add `with: fail-threshold: 70` later if you want PRs to fail on low scores
- **Not a build replacement** — this is review automation for skill markdown only, not a substitute for your own build/compile pipeline
- **Why only 5 skills here?** — keeps this PR reviewable. After merge, every PR that touches `SKILL.md` gets automatic review comments, so improvement spreads across the whole skill library over time
</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏